### PR TITLE
Fix order time filter

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -112,9 +112,6 @@ def is_valid_order(order):
     if any(word in order["time_info"] for word in CONFIG["FILTERS"]["TIME_KEYWORDS"]):
         return False
 
-    # Фильтр по времени публикации
-    if order["time_info"] == '1 минуту назад':
-        return False
 
     # Фильтр по ключевым словам
     if any(bad_word.lower() in order["subject"].lower() for bad_word in CONFIG["FILTERS"]["BAD_WORDS"]):


### PR DESCRIPTION
## Summary
- remove unnecessary time filter that skipped 1 minute old orders

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685ec5e6e9688330b135ef045c66035d